### PR TITLE
Document usage of '--locked' when installing with dataframe feature

### DIFF
--- a/snippets/installation/cargo_install_nu_more_features.sh
+++ b/snippets/installation/cargo_install_nu_more_features.sh
@@ -1,1 +1,1 @@
-> cargo install nu --features=dataframe
+> cargo install nu --locked --features=dataframe


### PR DESCRIPTION
Update documentation to reflect the requirement for the `--locked` cargo flag when installing with the `dataframe` feature.

This has been mentioned earlier in the following issues, but was only fixed in the scripts in the nushell repository:
- nushell/nushell#10014
- nushell/nushell#10084
